### PR TITLE
[CTA] allows multiple lines via config array

### DIFF
--- a/cta.php
+++ b/cta.php
@@ -12,7 +12,15 @@
                     <img src="<?= \Arr::get($region, 'image');?>" alt="<?= \Arr::get($region, 'title');?>" class="scale-with-grid">
 
                     <h5><?= \Arr::get($region, 'title', 'Default');?></h5>
-                    <p><?= \Str::truncate(\Arr::get($region, 'content', 'Default content, please add your own.'), 200, '...');?></p>
+                    
+                    <?php $content = \Arr::get($region, 'content', 'Default content, please add your own.'); ?>
+                    <?php if(is_string($content)): ?>
+                        <p><?= \Str::truncate($content, 200, '...');?></p>
+                    <?php elseif(is_array($content)): ?>
+                        <?foreach ($content as $line): ?>
+                            <p><?= $line; ?></p>
+                        <?php endforeach; ?>
+                    <?php endif; ?>
 
                     <? if(isset($region['button'])) :?>
                    

--- a/events.php
+++ b/events.php
@@ -24,8 +24,11 @@ $events = $calendar->get_events('today', \Arr::get($config, 'events', '+1 month'
                         <? foreach($date_events as $event):?>
                             <div class="events__slide">
 
-                               <? $date = strtotime($event->date_start);?>          
-
+                               <? $date = strtotime($event->date_start);?>
+                                <? if(\Arr::get($config, 'link')) :?>
+                                    <a href="<?= \Arr::get($config, 'link').'#'.$event->id;?>">
+                                <? endif;?>
+                               
                                 <? if($event->image_id) :?>
                                     <? if(\Arr::get($config, 'link')) :?>
                                         <a href="<?= \Arr::get($config, 'link');?>">
@@ -48,7 +51,7 @@ $events = $calendar->get_events('today', \Arr::get($config, 'events', '+1 month'
                                     <div class="events__title">                                       
                                         <h5>
                                             <? if(\Arr::get($config, 'link')) :?>
-                                            <a href="<?= \Arr::get($config, 'link');?>">
+                                            <a href="<?= \Arr::get($config, 'link').'#'.$event->id;?>">
                                             <? endif;?>
                                             <?= \Str::truncate($event->name, 30, '...');?>
                                             <? if(\Arr::get($config, 'link')) :?>
@@ -59,6 +62,7 @@ $events = $calendar->get_events('today', \Arr::get($config, 'events', '+1 month'
                                 </div>                                
 
                             </div>
+
                         <? $i++;?>
                         <? endforeach;?>
                     <? endforeach;?>


### PR DESCRIPTION
The thetrafalgararms.co.uk wants to split out CTA text into lines so I needed to implement content key as array.


Also added anchor targets to the events slider so they point to the right event on the page.


refer to change no: 107236

Many thanks,

César