### PR TITLE
[bugfix-sections-variable-name] - Fix colour variable name

### DIFF
--- a/styles/_button.scss
+++ b/styles/_button.scss
@@ -43,11 +43,11 @@
 
         &--menu {
 
-            background: $quniaryColor;
+            background: $quinaryColor;
 
             &:hover, &.active {
-                border: 4px solid $quniaryColor;
-                color: $quniaryColor;
+                border: 4px solid $quinaryColor;
+                color: $quinaryColor;
             }
 
         }

--- a/styles/_menu.scss
+++ b/styles/_menu.scss
@@ -21,12 +21,12 @@
         padding: 15px;
         margin-bottom: 2%;
         background: transparent;
-        border-color: $quniaryColor;
-        color: $quniaryColor;
+        border-color: $quinaryColor;
+        color: $quinaryColor;
 
         &.active,
         &:hover {
-            background: $quniaryColor;
+            background: $quinaryColor;
             color: $white;
         }
         
@@ -67,7 +67,7 @@
                 width: 100%;
                 bottom: 50px;
                 left: 0;
-                color: $quniaryColor;
+                color: $quinaryColor;
                 font-family: $fonticon !important;
                 font-style: normal !important;
                 font-weight: normal !important;
@@ -157,7 +157,7 @@
     
     h3 {
         
-        border-bottom: 5px solid $quniaryColor;
+        border-bottom: 5px solid $quinaryColor;
         padding-bottom: 10px;
         margin-bottom: 25px;
         padding-top: 20px;


### PR DESCRIPTION
Colour variable is called $quniaryColor instead of $quinaryColor . Breaks compiling if people use correct name, for ex. on The Grocer Spitalfields.

Please also check and update PR "bugfix-template-variable-name" on the R7 template or it's going to break everything.

Job nr: TBC. I'll post another comment once Hayley emails it to me.