### PR TITLE
[feature-dmn-console-layout] changing opacity and centering booking c…

### DIFF
--- a/styles/_design-my-night.scss
+++ b/styles/_design-my-night.scss
@@ -12,7 +12,15 @@
 			z-index: 100;
 			padding: 20px 0;
 			-webkit-backdrop-filter: blur(15px);
-			@include rgba('background-color', rgba($black, 0.6), $black);
+			@include rgba('background-color', rgba($black, 0.9), $black);
+			overflow: auto;
+
+			.centre-wrap--centred {
+				position: absolute;
+				left: 50%;
+				top: 50%;
+				transform: translate(-50%, -50%);
+			}
 
 			.book__wrapper {
 				position: relative;


### PR DESCRIPTION
changing opacity and centering booking console

It's design fix to keep booking console on middle of the screen horizontally and vertically and some opacity to match our current websites' design.

It also amends this one: https://github.com/propcom/R7-sections/pull/16