### PR TITLE
Use short month names instead of full

### DIFF
--- a/events-new.php
+++ b/events-new.php
@@ -58,7 +58,7 @@
 
                         <div class="events__full-info events__full-info--wide">
                             <div class="events__date events__date--wide events__date--tertiary-color" id="<?= date('d', $date);?>">
-                                <span><?= date('F', $date);?></span>
+                                <span><?= date('M', $date);?></span>
                                 <p><?= date('d', $date);?></p>
                             </div>
                             <div class="events__title events__title--narrow">

--- a/events.php
+++ b/events.php
@@ -47,10 +47,10 @@ $events = $calendar->get_events('today', \Arr::get($config, 'events', '+1 month'
 
                                     <div class="events__info">
                                         <div class="events__date">
-                                                <span><?= date('F', $date);?></span>
+                                                <span><?= date('M', $date);?></span>
                                                 <p><?= date('d', $date);?></p>
                                         </div>
-                                        <div class="events__title">                                       
+                                        <div class="events__title">
                                             <h5>
                                                 <? if(\Arr::get($config, 'link')) :?>
                                                 <a href="<?= \Arr::get($config, 'link').'?month='.date('M', $date).'#'.$event->id;?>">


### PR DESCRIPTION
Change long month name to 3 letter name to prevent overflow of longer month names, e.g. http://www.thebullsheadbarnes.com/whats-on