### PR TITLE
[Gallery] - Fix slider when multiple galleries

### DIFF
--- a/gallery.php
+++ b/gallery.php
@@ -21,24 +21,24 @@
     <? $a = 0;?>
     
     <? foreach ($albums as $album) : ?>
-    
+
         <div class="js-gallery">
 
             <? $images = $album->images();?>
             
             <? $i = 1; ?>
             
-            <? foreach($images as $image) :?>
+            <? foreach($images as $index => $image) :?>
 
                 <? if(($i == 1) || ($i == 7)): ?>
                     <div class="gallery__section">
                 <? endif; ?>
 
-                <div class="js-gallery-img  gallery__img--bg  gallery__img<?= $i == 5 ? ' gallery__img--large  gallery__img--large--right' : ''; ?> <?= $i == 6 ? ' gallery__img--large  gallery__img--large--left' : '';?>">
+                <div class="js-gallery-img  gallery__img--bg  gallery__img<?= $i == 5 ? ' gallery__img--large  gallery__img--large--right' : ''; ?> <?= $i == 6 ? ' gallery__img--large  gallery__img--large--left' : '';?>" data-slide_index="<?= $index ?>">
                     <span class="gallery__img--bg__img" style="background-image: url(<?= $image->get_src('medium');?>);"></span>
                 </div>
 
-                <? if(($i == 4) || ($i == 10)): ?>
+                <? if(($i == 4) || ($i == 10) || ($index == count($images)-1)): ?>
                     </div>
                 <? endif; ?>
            

--- a/styles/_gallery.scss
+++ b/styles/_gallery.scss
@@ -47,6 +47,7 @@
     &__slider {
         
         background: $primaryColor;
+        display: none;
         
         &.active {
             


### PR DESCRIPTION
Job number: 4281
Change number: 119375

I've closed the div of gallery__section which didn't close properly. I hide gallery sliders by default and show only the active gallery.
