### PR TITLE
[Events] resized narrow events block to keep them inline

### DIFF
--- a/styles/_events.scss
+++ b/styles/_events.scss
@@ -206,10 +206,14 @@
 
         &--narrow {
             position: relative;
-            width: 23%;
-            float:left;
+            width: 22%;
+            display: inline-block;
+            vertical-align: top;
 
-            margin-right: 2%;
+            margin: {
+                left: 1%;
+                right: 1%;
+            }
             padding: 12px;
             padding-bottom: 60px;
             border: 3px solid $primaryColor;
@@ -218,7 +222,7 @@
             min-height: 700px;
 
             @include mq(1000px) {
-                width: 48%;
+                width: 47%;
                 min-height: 685px;
             }
 


### PR DESCRIPTION
Added display inline block and fixed width to keep all blocks inline, otherwise layout looks broken when there is a lot of events with different divs height

output: http://adrian.thebullsheadbarnes.com.dev/whats-on
source: http://www.thebullsheadbarnes.com/whats-on?month=May#events-container
change: http://control.propeller.me.uk/chc_change_details.asp?changeid=125166