### PR TITLE
[Instagram]: occasionally caption is null.

### DIFF
--- a/instagram.php
+++ b/instagram.php
@@ -115,7 +115,7 @@ $insta = new Instagram( \Arr::get( $insta_cfg, 'user_id' ), \Arr::get( $insta_cf
 
                 <? else : ?>
 
-                    <a href="<?= $photo->link; ?>" target="_blank" title="<?= $photo->caption->text; ?>">
+                    <a href="<?= $photo->link; ?>" target="_blank" title="<?= $photo->caption ? $photo->caption->text : '-' ?>">
                         <img src="data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw==" zRS-src="<?= $src->url; ?>" alt="<?= $sitename; ?>" height="<?= $src->height; ?>" width="<?= $src->width; ?>">
                     </a>
 


### PR DESCRIPTION
Client  Propeller Communications - not chargeable
Job  1/00041133 Propeller Projects
Phase 056 AWS Hosting Migration
Stage  Web1 Sites - DNS Switchover

"Trying to get property of non-object" errors.
